### PR TITLE
Add supported functions and WAN info

### DIFF
--- a/aioasuswrt/asuswrt.py
+++ b/aioasuswrt/asuswrt.py
@@ -92,6 +92,47 @@ GET_LIST = {
         "reboot_schedule_enable",
         "reboot_time"
     ],
+    "WANS": [
+        "link_internet",
+        "wan_unit",
+        "wans_cap",
+        "wans_dualwan",
+        "wans_lanport",
+        "wans_lb_ratio",
+        "wans_mode",
+        "wans_routing_enable",
+        "wans_standby",
+    ],
+    "WAN0": [
+        "wan0_auxstate_t",
+        "wan0_dns",
+        "wan0_dns1_x",
+        "wan0_dns2_x",
+        "wan0_dnsenable_x",
+        "wan0_enable",
+        "wan0_gateway",
+        "wan0_ipaddr",
+        "wan0_is_usb_modem_ready",
+        "wan0_primary",
+        "wan0_sbstate_t",
+        "wan0_state_t",
+        "wan0_unit",
+    ],
+    "WAN1": [
+        "wan1_auxstate_t",
+        "wan1_dns",
+        "wan1_dns1_x",
+        "wan1_dns2_x",
+        "wan1_dnsenable_x",
+        "wan1_enable",
+        "wan1_gateway",
+        "wan1_ipaddr",
+        "wan1_is_usb_modem_ready",
+        "wan1_primary",
+        "wan1_sbstate_t",
+        "wan1_state_t",
+        "wan1_unit",
+    ],
     "WLAN": [
         "wan_dns",
         "wan_domain",
@@ -387,6 +428,24 @@ class AsusWrt:
         rx, tx = await self.async_get_current_transfer_rates(use_cache)
 
         return "%s/s" % convert_size(rx), "%s/s" % convert_size(tx)
+    
+    async def async_get_wan(self):
+        """Gets status parameters relating to WAN"""
+        values = await asyncio.gather(
+            self.async_get_nvram("WANS"),
+            self.async_get_nvram("WAN0"),
+            self.async_get_nvram("WAN1"),
+        )
+        return {
+            "wans": values[0],
+            "wan0": values[1],
+            "wan1": values[2],
+        }
+
+    async def async_get_supported_functions(self):
+        """Gets comma seperated list of router supported functions"""
+        fn = await self.async_get_nvram("SUPPORT")
+        return fn.get("rc_support", "").split()
 
     @property
     def is_connected(self):

--- a/aioasuswrt/asuswrt.py
+++ b/aioasuswrt/asuswrt.py
@@ -1,4 +1,5 @@
 """Module for Asuswrt."""
+import asyncio
 import inspect
 import logging
 import math


### PR DESCRIPTION
Hi,

Would you please consider this PR to add methods to:
a) return the functions supported by the router as a comma seperated list
b) return info about the overall WAN status and the wan0 and wan1 connections

I am looking to enhance the asuswrt integration for Home Assistant and this will allow monitoring of the internet connection status reported by the router in either single or dual WAN mode.

I looked at the test_regex.py file but could not determine if these changes should have a test in their as they only appear to test calling router functions and not nvram values.  Please let me know if this does need a test and a little pointer as to what I should be testing.

I have however run the test_regex through tox and it passed without error with this change implemented.

I have also only tested this on an ASUS RT-AX92U.

KR
Mark