### PR TITLE
asyncio.streams.IncompleteReadError -> asyncio.IncompleteReadError

### DIFF
--- a/aioasuswrt/connection.py
+++ b/aioasuswrt/connection.py
@@ -127,7 +127,7 @@ class TelnetConnection:
         with (await self._io_lock):
             try:
                 await asyncio.wait_for(self._reader.readuntil(b'login: '), 9)
-            except asyncio.streams.IncompleteReadError:
+            except asyncio.IncompleteReadError:
                 _LOGGER.error(
                     "Unable to read from router on %s:%s" % (
                         self._host, self._port))


### PR DESCRIPTION
The line "except asyncio.streams.IncompleteReadError:" was throwing the following AttributeError error.

AttributeError: module 'asyncio.streams' has no attribute 'IncompleteReadError'