### PR TITLE
Remove pytest-runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
     name='aioasuswrt',
     version=VERSION,
     description='Api wrapper for Asuswrt https://www.asus.com/ASUSWRT/',
-    setup_requires=['pytest-runner'],
     long_description=long_description,
     long_description_content_type="text/markdown",
     url='https://github.com/kennedyshead/aioasuswrt',


### PR DESCRIPTION
Distribution packages are pulling `pytest-runner` during the build process but it's not used.