### PR TITLE
fix failing tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,55 +7,54 @@ https://github.com/pypa/sampleproject
 """
 
 # Always prefer setuptools over distutils
-from setuptools import setup, find_packages
-from os import path
+from setuptools import find_packages, setup
 
-here = path.abspath(path.dirname(__file__))
-
-__author__ = 'Magnus Knutas'
-VERSION = '1.3.3'
+__author__ = "Magnus Knutas"
+VERSION = "1.3.3"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-install_requires = [
-    'cryptography==3.3.2',
-    'asyncssh'
+install_requires = ["cryptography==3.3.2", "asyncssh"]
+
+tests_requires = [
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+    "pytest-asyncio",
 ]
 
-tests_require = [
-    'pytest',
-    'pytest-cov',
-    'pytest-mock',
-    'pytest-asyncio'
-]
+setup_requires = ["pytest-runner"]
 
-extras_require = {
-    'dev': ['check-manifest'],
+extras_requires = {
+    "dev": ["check-manifest"],
 }
 
+github_url = "https://github.com/kennedyshead/aioasuswrt"
+
 setup(
-    name='aioasuswrt',
+    name="aioasuswrt",
     version=VERSION,
-    description='Api wrapper for Asuswrt https://www.asus.com/ASUSWRT/',
+    description="Api wrapper for Asuswrt https://www.asus.com/ASUSWRT/",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://github.com/kennedyshead/aioasuswrt',
-    download_url='https://github.com/kennedyshead/aioasuswrt/archive/%s.tar.gz' % VERSION,
+    url=github_url,
+    download_url=f"{github_url}/archive/{VERSION}.tar.gz",
     author=__author__,
-    author_email='magnusknutas@gmail.com',
+    author_email="magnusknutas@gmail.com",
     license="MIT",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'Topic :: Software Development :: Libraries',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3',
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
     ],
-    keywords='Asuswrt wrapper',
-    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+    keywords="Asuswrt wrapper",
+    packages=find_packages(exclude=["contrib", "docs", "tests"]),
     install_requires=install_requires,
-    test_suite='tests',
-    tests_require=tests_require,
-    extras_require=extras_require,
+    setup_requires=setup_requires,
+    tests_require=tests_requires,
+    extras_require=extras_requires,
+    test_suite="tests",
 )


### PR DESCRIPTION
Add the pytest-runner to the test requirements such that the tests succeed again. For more info see also:
https://docs.pytest.org/en/reorganize-docs/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner

If pytest-runner is not an option to use we could also do the manual integration specified there.