### PR TITLE
fix: Removed deprecated setuptools parameters

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
+          pip install flake8 tox
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |
@@ -33,6 +33,6 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Test with pytest
+      - name: Test with tox
         run: |
-          python setup.py test
+          tox

--- a/setup.py
+++ b/setup.py
@@ -17,15 +17,6 @@ with open("README.md", "r") as fh:
 
 install_requires = ["cryptography==3.3.2", "asyncssh"]
 
-tests_requires = [
-    "pytest",
-    "pytest-cov",
-    "pytest-mock",
-    "pytest-asyncio",
-]
-
-setup_requires = ["pytest-runner"]
-
 extras_requires = {
     "dev": ["check-manifest"],
 }
@@ -53,8 +44,6 @@ setup(
     keywords="Asuswrt wrapper",
     packages=find_packages(exclude=["contrib", "docs", "tests"]),
     install_requires=install_requires,
-    setup_requires=setup_requires,
-    tests_require=tests_requires,
     extras_require=extras_requires,
     test_suite="tests",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = python
+minversion = 3.6
+
+[testenv]
+deps = 
+    pytest 
+    pytest-cov 
+    pytest-mock 
+    pytest-asyncio
+commands = pytest


### PR DESCRIPTION
@fabaff This seems to be the preferred solution with removing the tests_required / setup_required parameters from setuptools.