### PR TITLE
Change the crypto requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ VERSION = "1.3.3"
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-install_requires = ["cryptography==3.3.2", "asyncssh"]
+install_requires = ["asyncssh"]
 
 extras_requires = {
     "dev": ["check-manifest"],


### PR DESCRIPTION
We can remove the `cryptography` requirement as we don't require it directly (but through asyncssh).

This change does mean that we require users to upgrade their pip before you're able to install the requirements (The raised error is shown for example in this previously run workflow):
https://github.com/kennedyshead/aioasuswrt/runs/1892985827?check_suite_focus=true#step:6:25

This also aligns the library with the requirements from HomeAssistent for including it as mentioned in home-assistant/core#48582