### PR TITLE
Force SSH key algorithm to RSA

### DIFF
--- a/aioasuswrt/connection.py
+++ b/aioasuswrt/connection.py
@@ -72,6 +72,7 @@ class SshConnection:
             "port": self._port,
             "password": self._password if self._password else None,
             "known_hosts": None,
+            'server_host_key_algs': ['ssh-rsa'],
         }
 
         self._client = await asyncssh.connect(self._host, **kwargs)


### PR DESCRIPTION
The latest v2.6 asyncssh library has started causing host key algorithm errors again with some older versions of ASUS FW. (The same issues that occurred prior to being fixed in asyncssh v2.3).

See https://github.com/home-assistant/core/issues/50132

Forcing RSA results in connections working to my older versioned (384.13_10) AC87U.

I guess one question here is will this affect SSH to newer FW models? I only have the single device so cannot test this.