### PR TITLE
Fix UnicodeDecodeError error on Telnet connection

### DIFF
--- a/aioasuswrt/connection.py
+++ b/aioasuswrt/connection.py
@@ -137,7 +137,7 @@ class TelnetConnection:
         # We have to do floor + 1 to handle the infinite case correct
         start_split = floor(cmd_len / self._linebreak) + 1
         data = data[start_split:-1]
-        return [line.decode("utf-8") for line in data]
+        return [line.decode("utf-8", "ignore") for line in data]
 
     async def async_connect(self):
         """Connect to the ASUS-WRT Telnet server."""


### PR DESCRIPTION
This PR should fix issue #76 caused by `UnicodeDecodeError` raised calling some commands when using telnet connection.