### PR TITLE
Update instructions for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@ Small wrapper for asuswrt. ![Python package](https://github.com/kennedyshead/aio
 
 ### How to run tests
 
-`python setup.py test`
+Install [tox](https://tox.wiki/en/latest/)
+```bash
+pip install tox
+```
+
+Run the tests:
+```bash
+tox
+```
 
 ## Credits:
 [@mvn23](https://github.com/mvn23)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ description-file = README.md
 
 [tool:pytest]
 addopts = --durations=10 --cov-report html --cov-report term-missing -x
+asyncio_mode = strict
 
 [flake8]
 ignore = E501


### PR DESCRIPTION
I tried using the testing instructions but they do not work as they depend on a bunch of test dependencies being in place. While investigating I also discovered that running tests through setuptools is [no longer recommended](https://docs.pytest.org/en/latest/explanation/goodpractices.html#do-not-run-via-setuptools). I have updated the instructions to follow the steps taken in the GitHub action.

I have also explicitly set the `asyncio_mode` as this was raising a warning. It looks like the other warnings will be addressed [when asyncssh is updated](https://github.com/ronf/asyncssh/issues/473).
