### PR TITLE
Use wan_interface instead of hard-coding eth0

### DIFF
--- a/aioasuswrt/asuswrt.py
+++ b/aioasuswrt/asuswrt.py
@@ -307,7 +307,7 @@ class AsusWrt:
 
         def _add_if_match(line: str) -> TransferRates | None:
             parts = split(r"[\s:]+", line.strip())
-            if parts[0] in ["eth0", "vlan1"]:
+            if parts[0] in [self.wan_interface, "vlan1"]:
                 return TransferRates(
                     handle32bitwrap(int(parts[1])),
                     handle32bitwrap(int(parts[9])),


### PR DESCRIPTION
On some firmwares such as Padavan custom firmware for rt-n56u, the wan interface is called eth3 instead of eth0.